### PR TITLE
Merging Final changes from Develop

### DIFF
--- a/.github/workflows/develop.yaml
+++ b/.github/workflows/develop.yaml
@@ -98,6 +98,8 @@ jobs:
           echo "Updating Helm chart..."
           sed -i "s|^\s*repository: .*|  repository: $IMAGE_REPO_NAME|" helm-chart/values-gradle-dev.yaml
           sed -i "s|^\s*tag: .*|  tag: $IMAGE_TAG|" helm-chart/values-gradle-dev.yaml
+          sed -i "s|^\s*repository: .*|  repository: $IMAGE_REPO_NAME|" helm-chart/values-gradle.yaml
+          sed -i "s|^\s*tag: .*|  tag: $IMAGE_TAG|" helm-chart/values-gradle.yaml
           echo "Updated Helm chart:"
           cat helm-chart/values-gradle-dev.yaml
 
@@ -108,5 +110,5 @@ jobs:
         with:
           default_author: github_actor
           message: "Update deployment image to ${{ env.IMAGE_TAG }}"
-          add: 'helm-chart/values-gradle-dev.yaml'
+          add: 'helm-chart/values-gradle-dev.yaml helm-chart/values-gradle.yaml'
           new_branch: develop

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -43,11 +43,13 @@ jobs:
           ref: main
           token: ${{ secrets.REPO_TOKEN }}
 
-      - name: Update Helm chart Image Tag
+      - name: Update Helm chart Image Tag in dev-file and prod-file so that we have dev and prod in sync.
         run: |
           echo "Updating Helm chart in Argo repo..."
           sed -i "s|^\s*repository: .*|  repository: $IMAGE_REPO_NAME|" helm-chart/values-gradle.yaml
           sed -i "s|^\s*tag: .*|  tag: $IMAGE_TAG|" helm-chart/values-gradle.yaml
+          sed -i "s|^\s*repository: .*|  repository: $IMAGE_REPO_NAME|" helm-chart/values-gradle-dev.yaml
+          sed -i "s|^\s*tag: .*|  tag: $IMAGE_TAG|" helm-chart/values-gradle-dev.yaml
           echo "Updated Helm chart:"
           cat helm-chart/values-gradle.yaml
 
@@ -56,5 +58,5 @@ jobs:
         with:
           default_author: github_actor
           message: "Update deployment image to $IMAGE_TAG from develop"
-          add: 'helm-chart/values-gradle.yaml'
+          add: 'helm-chart/values-gradle.yaml helm-chart/values-gradle-dev.yaml'
           new_branch: main


### PR DESCRIPTION
Now, we are updating both values.yaml at once, so that when we merge the Develop branch it make changes in both files and make main branch of Helm-git-repo equal to develop branch.
Updating main values file in develop will not impact prod argo deployment since pro argocd uses files from main branch. It will only take changes when we merge develop branch into main branch of application repo.